### PR TITLE
Inconsistencies in weighing functions

### DIFF
--- a/src/common/config_blur.h
+++ b/src/common/config_blur.h
@@ -7,7 +7,7 @@ struct AdvancedSettings {
 	std::string ffmpeg_override;
 	bool debug = false;
 
-	float blur_weighting_gaussian_std_dev = 2.f;
+	float blur_weighting_gaussian_std_dev = 1.f;
 	bool blur_weighting_triangle_reverse = false;
 	std::string blur_weighting_bound = "[0,2]";
 

--- a/src/vapoursynth/blur/weighting.py
+++ b/src/vapoursynth/blur/weighting.py
@@ -26,13 +26,13 @@ def equal(frames):
     return [1 / frames] * frames
 
 
-def gaussian(frames, standard_deviation=2, bound=[0, 2]):
+def gaussian(frames, standard_deviation=1, bound=[0, 2]):
     r = scale_range(frames, bound[0], bound[1])
-    val = [math.exp(-((x) ** 2) / (2 * (standard_deviation**2))) for x in r]
+    val = [math.exp(-((x) ** 2) / (2 * (standard_deviation**2))) for x in reversed(r)]
     return scale_weights(val)
 
 
-def gaussian_sym(frames, standard_deviation=2, bound=[0, 2]):
+def gaussian_sym(frames, standard_deviation=1, bound=[0, 2]):
     max_abs = max(bound)
     r = scale_range(frames, -max_abs, max_abs)
     val = [math.exp(-((x) ** 2) / (2 * (standard_deviation**2))) for x in r]


### PR DESCRIPTION
[blur v2.2]

The weighing functions are kind of unintuitive.

Pyramid and gaussian both have symmetric counterparts, so you'd expect them to both either be rising or descending. But they don't - gaussian decreases whereas pyramid increases.
![Figure_1](https://github.com/user-attachments/assets/a703380a-b5ce-4e48-99c9-477b292e4d45)

Figure is taken by plotting functions in `weighting.py`. I checked just in case, and yes, they are reverse:

https://github.com/user-attachments/assets/f7cc0680-80c3-44a1-ac67-2e7c3baab96c

Moreover, it wasn't obvious to me before plotting that gaus and pyr, symmetric or not, have a different range. Together with that and the non-symmetric variants going in the same direction, I expected the plot using default values to look more like this, instead of the one above:
![Figure_2](https://github.com/user-attachments/assets/fb745411-e9b1-4eff-8648-365df05633f2)

This is realistically an issue, not a PR, since I don't know how you want to handle this, maybe naming the functions differently or adding different parameters for each, etc. But for simplicity, this PR includes the changes to make the plot look like the one above, i.e. switching the direction of nonsym gaussian to be increasing and changes the stddev for gaussian from 2 to 1.
