### PR TITLE
Fix config path and output path resolution

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -75,9 +75,10 @@ bool cli::run(
 		if (manual_output_files) {
 			output_path = outputs[i];
 
-			// create output directory if needed
-			if (!std::filesystem::exists(output_path->parent_path()))
-				std::filesystem::create_directories(output_path->parent_path());
+			// create output directory if needed (skip if parent is empty, i.e., current dir)
+			auto parent = output_path->parent_path();
+			if (!parent.empty() && !std::filesystem::exists(parent))
+				std::filesystem::create_directories(parent);
 		}
 
 		// set up render

--- a/src/common/rendering.cpp
+++ b/src/common/rendering.cpp
@@ -130,7 +130,7 @@ Render::Render(
 
 	// parse config file (do it now, not when rendering. nice for batch rendering the same file with different settings)
 	auto config_res = config_blur::get_config(
-		config_path.has_value() ? output_path.value() : config_blur::get_config_filename(m_video_folder),
+		config_path.has_value() ? config_path.value() : config_blur::get_config_filename(m_video_folder),
 		!config_path.has_value() // use global only if no config path is specified
 	);
 


### PR DESCRIPTION
- Parse config_path correctly
- Support output path in current directory
  - This supports `-o video.mp4` instead of specifying the absolute path of output file. 
    ```
    Handles:
    terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
      what():  filesystem error: cannot create directories: Invalid argument []
    ```